### PR TITLE
fix: count does not send the context

### DIFF
--- a/src/ngsildclient/api/client.py
+++ b/src/ngsildclient/api/client.py
@@ -566,7 +566,7 @@ class Client:
         """
 
         entities: list[Entity] = []
-        count = self.entities.count(type, q)
+        count = self.entities.count(type, q, ctx=ctx)
         if count > max:
             raise NgsiClientTooManyResultsError(f"{count} results exceed maximum {max}")
         for page in range(ceil(count / limit)):

--- a/src/ngsildclient/api/entities.py
+++ b/src/ngsildclient/api/entities.py
@@ -165,7 +165,7 @@ class Entities:
         return [Entity.from_dict(entity) for entity in entities]
 
     @rfc7807_error_handle
-    def count(self, type: str = None, q: str = None, **kwargs) -> int:
+    def count(self, type: str = None, q: str = None, ctx: str = None, **kwargs) -> int:
         params = {"limit": 0, "count": "true"}
         if type is None and q is None:
             raise ValueError("Must indicate at least a type or a query string")
@@ -173,12 +173,18 @@ class Entities:
             params["type"] = type
         if q:
             params["q"] = q
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": None,
+        }  # overrides session headers
+        if ctx is not None:
+            headers[
+                "Link"
+            ] = f'<{ctx}>; rel="{JSONLD_CONTEXT}"; type="application/ld+json"'
         r = self._session.get(
             self.url,
-            headers={
-                "Accept": "application/json",
-                "Content-Type": None,
-            },  # overrides session headers
+            headers=headers,
             params=params,
         )
         r.raise_for_status()


### PR DESCRIPTION
The count API method does not send the context. This prevents some query filters (q=...) to be applied.